### PR TITLE
[Fix #1] Add onEnd callback when commands are executed

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -76,6 +76,9 @@ module.exports = function (options) {
   });
   ssh.on('end', function () {
     gutil.log('SSH :: end');
+    if(options.onEnd) {
+      options.onEnd();
+    }
   });
   ssh.on('close', function () {
     gutil.log('SSH :: close');


### PR DESCRIPTION
Adding a callback on the end of the commands as @willemvb suggests it.
