### PR TITLE
Fixed deinit method then plugin is not used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function GulpSSH(options) {
     });
 
   gulp.once('stop', function () {
-    ctx.ssh2.end();
+    if ( ctx._connected ) {
+      ctx.ssh2.end();
+    }
   });
 }
 


### PR DESCRIPTION
[19:17:27] Using gulpfile ~/git/formula/gulpfile.js
[19:17:27] Starting 'clean'...
[19:17:27] Finished 'clean' after 11 ms

/home/progg/git/formula/node_modules/gulp-ssh/node_modules/ssh2/lib/Connection.js:881
  if (this._sock.writable && this._state === 'authenticated')
                ^
TypeError: Cannot read property 'writable' of undefined
    at Connection.end (/home/progg/git/formula/node_modules/gulp-ssh/node_modules/ssh2/lib/Connection.js:881:17)
    at Gulp.<anonymous> (/home/progg/git/formula/node_modules/gulp-ssh/index.js:52:14)
    at Gulp.g (events.js:180:16)
    at Gulp.EventEmitter.emit (events.js:95:17)
    at Gulp.Orchestrator.stop (/home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/index.js:142:9)
    at Gulp.Orchestrator._runStep (/home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/index.js:221:9)
    at /home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/index.js:279:18
    at finish (/home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
    at /home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:52:4
    at f (/home/progg/git/formula/node_modules/gulp/node_modules/orchestrator/node_modules/end-of-stream/node_modules/once/once.js:17:25)