### PR TITLE
Adds missing `fs` dependency to "readme.md" example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ npm install --save-dev gulp-ssh
 ```js
 'use strict'
 
+var fs = require('fs');
 var gulp = require('gulp')
 var GulpSSH = require('gulp-ssh')
 


### PR DESCRIPTION
I have actually fixed it, because I decided to try to use Gulp for simple SSH deployments. And after copy/pasting one of the tasks I experienced the issue with missing `fs`. 

Therefore, by trying to prevent next Gulp newbies to face the issue, just fixing it directly in your example.