### PR TITLE
increase test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "standard": "^10.0.3"
   },
   "scripts": {
-    "test": "standard && mocha",
+    "test": "standard && mocha -t 5000",
     "samples": "gulp samples"
   },
   "ignore": [


### PR DESCRIPTION
The default timeout is too low for CI environments. Increase the timeout to 5s.